### PR TITLE
Updated memory linking in configuration

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,7 +3,7 @@
 runner = "msp430-elf-gdb -q -x mspdebug.gdb"
 
 rustflags = [
-    "-C", "link-arg=-Tlink.x",
+    "-C", "link-arg=-Tmemory.x",
     "-C", "link-arg=-nostartfiles",
 
     # Between approximately version 6.4.0 and 8.3.1 (non-inclusive) of the


### PR DESCRIPTION
Dear Rust Embedded Team,

I have made a minor change to your quickstart guide.

The current Rustflags are misconfigured and do not allow adding no_std packages.
The `-T` flag is linking to a file that does not exist, however, the compiler does not complain about it. I updated the file to reference the proper file, which will allow the compilation of projects with no_std packages.

Best Regards,
@BBPL